### PR TITLE
Use alternatives

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-lmod_module_path: [ "/uollinapps/modules/unified" ]
+lmod_module_path: [ "/uollinapps/modules/unified:/usr/share/modulefiles" ]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,6 @@
   when: lmod_module_path | length > 0
 
 - name: set LMOD module path as preffered alternative
-  community.general.alternatives:
+  alternatives:
     name: modules.sh
     path: /usr/share/lmod/lmod/init/profile

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,9 +2,6 @@
 - name: Install the 'lmod' package
   package: name=Lmod state=present
 
-- name: Ensure that the tcl-based 'environment-modules' package is not installed
-  package: name=environment-modules  state=absent
-
 - name: Set MODULEPATH variable.
   lineinfile:
     path: /etc/environment

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,3 +12,8 @@
     line: "MODULEPATH={{ lmod_module_path|join(':') }}"
     state: present
   when: lmod_module_path | length > 0
+
+- name: set LMOD module path as preffered alternative
+  community.general.alternatives:
+  name: modules.sh
+  path: /usr/share/lmod/lmod/init/profile

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,5 +12,5 @@
 
 - name: set LMOD module path as preffered alternative
   community.general.alternatives:
-  name: modules.sh
-  path: /usr/share/lmod/lmod/init/profile
+    name: modules.sh
+    path: /usr/share/lmod/lmod/init/profile


### PR DESCRIPTION
Merge in alternatives to manage module command. Stop removing environment-modules and set MODULEPATH to include /usr/share/modules .

We now no longer have to worry about software that depends on TCL Enviroment modules - it plays nicely with LMOD.