### PR TITLE
Add pre-commit config and fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+exclude: '^$'
+fail_fast: false
+repos:
+  - repo: https://github.com/ansible/ansible-lint
+    rev: v6.14.2
+    hooks:
+      - id: ansible-lint

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-lmod_module_path: [ "/uollinapps/modules/unified:/usr/share/modulefiles" ]
+lmod_module_path: ["/uollinapps/modules/unified:/usr/share/modulefiles"]

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,6 +3,7 @@ dependencies: []
 
 galaxy_info:
   role_name: lmod
+  namespace: uoleeds
   author: Aidan Richmond
   description: lmod for RHEL Linux.
   company: "University of Leeds"
@@ -10,10 +11,11 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - 8
+        - '8'
   galaxy_tags:
     - lmod
     - modules
     - rhel
+  min_ansible_version: "2.9"
 
 allow_duplicates: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,6 @@
   when: lmod_module_path | length > 0
 
 - name: Set LMOD module path as preffered alternative
-  community.general.alternatives:
+  ansible.builtin.alternatives:
     name: modules.sh
     path: /usr/share/lmod/lmod/init/profile

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,18 @@
 ---
 - name: Install the 'lmod' package
-  package: name=Lmod state=present
+  ansible.builtin.package:
+    name: Lmod
+    state: present
 
 - name: Set MODULEPATH variable.
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /etc/environment
     regexp: "MODULEPATH=.*"
-    line: "MODULEPATH={{ lmod_module_path|join(':') }}"
+    line: "MODULEPATH={{ lmod_module_path | join(':') }}"
     state: present
   when: lmod_module_path | length > 0
 
-- name: set LMOD module path as preffered alternative
-  alternatives:
+- name: Set LMOD module path as preffered alternative
+  community.general.alternatives:
     name: modules.sh
     path: /usr/share/lmod/lmod/init/profile


### PR DESCRIPTION
Intended as a conversation starter.  Use of commit hooks and linters can avoid common mistakes for minimal effort.  If you take it further you can add actions in github to ensure it passes necessary tests, but to start with, you could look at this as opt in.